### PR TITLE
[CN-29500] Upgrade hermosa to python 3.8/3.9

### DIFF
--- a/elixir/__init__.py
+++ b/elixir/__init__.py
@@ -39,7 +39,7 @@ from elixir.statements import Statement
 from elixir.collection import EntityCollection, GlobalEntityCollection
 
 
-__version__ = '0.9.0'
+__version__ = '1.0.1'
 
 __all__ = ['Entity', 'EntityBase', 'EntityMeta', 'EntityCollection',
            'entities',

--- a/elixir/collection.py
+++ b/elixir/collection.py
@@ -114,7 +114,7 @@ class RelativeEntityCollection(BaseCollection):
                     "'%s' relative to '%s'" % (key, entity.__module__))
             entity_module = '.'.join(chunks[:chunkstokeep])
 
-            if entity_module and entity_module is not '__main__':
+            if entity_module and entity_module != '__main__':
                 full_path = '%s.%s' % (entity_module, full_path)
 
             root = ''

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 setup(name="Elixir",
-      version="0.9.0",
+      version="1.0.1",
       description="Declarative Mapper for SQLAlchemy",
       long_description="""
 Elixir

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3
+envlist = py27,py3,py38,py39
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
When upgrading hermosa to 3.8/3.9 got a `SyntaxWarning` from this package:
```
/usr/local/lib/python3.9/site-packages/elixir/collection.py:117: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if entity_module and entity_module is not '__main__':
```

Updated syntax, added py38 and py39 to tox tests and upped package version.