### PR TITLE
Update elixir for Hermosa python 3.11 upgrade

### DIFF
--- a/elixir/__init__.py
+++ b/elixir/__init__.py
@@ -14,8 +14,6 @@ and instead focuses on providing a simpler syntax for defining model objects
 when you do not need the full expressiveness of SQLAlchemy's manual mapper
 definitions.
 '''
-from __future__ import absolute_import
-
 try:
     set
 except NameError:

--- a/elixir/__init__.py
+++ b/elixir/__init__.py
@@ -37,7 +37,7 @@ from elixir.statements import Statement
 from elixir.collection import EntityCollection, GlobalEntityCollection
 
 
-__version__ = '1.0.1'
+__version__ = '2.0.0'
 
 __all__ = ['Entity', 'EntityBase', 'EntityMeta', 'EntityCollection',
            'entities',

--- a/elixir/collection.py
+++ b/elixir/collection.py
@@ -1,8 +1,6 @@
 '''
 Default entity collection implementation
 '''
-from __future__ import absolute_import
-
 import sys
 import re
 

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -2,8 +2,6 @@
 This module provides the ``Entity`` base class, as well as its metaclass
 ``EntityMeta``.
 '''
-from __future__ import absolute_import, print_function
-
 from builtins import object
 from future.utils import with_metaclass
 from past.builtins import basestring

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -45,7 +45,7 @@ def session_mapper_factory(scoped_session):
     return session_mapper
 
 
-class EntityDescriptor(object):
+class EntityDescriptor:
     '''
     EntityDescriptor describes fields and options needed for table creation.
     '''
@@ -666,7 +666,7 @@ class EntityDescriptor(object):
             self._pk_props = [col_to_prop[c] for c in pk_cols]
         return self._pk_props
 
-class FakePK(object):
+class FakePK:
     def __init__(self, descriptor):
         self.descriptor = descriptor
 
@@ -674,7 +674,7 @@ class FakePK(object):
     def columns(self):
         return self.descriptor.primary_keys
 
-class FakeTable(object):
+class FakeTable:
     def __init__(self, descriptor):
         self.descriptor = descriptor
         self.primary_key = FakePK(descriptor)
@@ -856,7 +856,7 @@ def cleanup_entities(entities):
         desc.constraints = []
         desc.properties = {}
 
-class EntityBase(object):
+class EntityBase:
     """
     This class holds all methods of the "Entity" base class, but does not act
     as a base class itself (it does not use the EntityMeta metaclass), but

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -4,7 +4,6 @@ This module provides the ``Entity`` base class, as well as its metaclass
 '''
 from builtins import object
 from future.utils import with_metaclass
-from past.builtins import basestring
 import sys
 import types
 import warnings
@@ -174,7 +173,7 @@ class EntityDescriptor(object):
             self.identity = self.identity(entity)
 
         if self.polymorphic:
-            if not isinstance(self.polymorphic, basestring):
+            if not isinstance(self.polymorphic, str):
                 self.polymorphic = options.DEFAULT_POLYMORPHIC_COL_NAME
 
     #---------------------
@@ -231,7 +230,7 @@ class EntityDescriptor(object):
                         if col.primary_key:
                             self.add_column(col.copy())
             elif not self.has_pk and self.auto_primarykey:
-                if isinstance(self.auto_primarykey, basestring):
+                if isinstance(self.auto_primarykey, str):
                     colname = self.auto_primarykey
                 else:
                     colname = options.DEFAULT_AUTO_PRIMARYKEY_NAME
@@ -303,7 +302,7 @@ class EntityDescriptor(object):
                                        options.POLYMORPHIC_COL_TYPE))
 
             if self.version_id_col:
-                if not isinstance(self.version_id_col, basestring):
+                if not isinstance(self.version_id_col, str):
                     self.version_id_col = options.DEFAULT_VERSION_ID_COL_NAME
                 self.add_column(Column(self.version_id_col, Integer))
 
@@ -371,7 +370,7 @@ class EntityDescriptor(object):
         return children
 
     def translate_order_by(self, order_by):
-        if isinstance(order_by, basestring):
+        if isinstance(order_by, str):
             order_by = [order_by]
 
         order = []

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -3,7 +3,6 @@ This module provides the ``Entity`` base class, as well as its metaclass
 ``EntityMeta``.
 '''
 from builtins import object
-from future.utils import with_metaclass
 import sys
 import types
 import warnings
@@ -1021,7 +1020,7 @@ class EntityBase(object):
         return cls.query.get(*args, **kwargs)
 
 
-class Entity(with_metaclass(EntityMeta, EntityBase)):
+class Entity(EntityBase, metaclass=EntityMeta):
     '''
     The base class for all entities
 

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -2,7 +2,6 @@
 This module provides the ``Entity`` base class, as well as its metaclass
 ``EntityMeta``.
 '''
-from builtins import object
 import sys
 import types
 import warnings

--- a/elixir/events.py
+++ b/elixir/events.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from sqlalchemy.orm import reconstructor
 
 __all__ = [

--- a/elixir/ext/associable.py
+++ b/elixir/ext/associable.py
@@ -109,7 +109,6 @@ The generated Elixir Statement has several options available:
 |               | lazily loaded.                                              |
 +---------------+-------------------------------------------------------------+
 '''
-from builtins import object
 from elixir.statements import Statement
 import sqlalchemy as sa
 

--- a/elixir/ext/associable.py
+++ b/elixir/ext/associable.py
@@ -128,13 +128,13 @@ def associable(assoc_entity, plural_name=None, lazy=True):
         plural_name = interface_name
         attr_name = "%s_rel" % interface_name
 
-    class GenericAssoc(object):
+    class GenericAssoc:
 
         def __init__(self, tablename):
             self.type = tablename
 
     #TODO: inherit from entity builder
-    class Associable(object):
+    class Associable:
         """An associable Elixir Statement object"""
 
         def __init__(self, entity, name=None, uselist=True, lazy=True):

--- a/elixir/ext/associable.py
+++ b/elixir/ext/associable.py
@@ -109,7 +109,6 @@ The generated Elixir Statement has several options available:
 |               | lazily loaded.                                              |
 +---------------+-------------------------------------------------------------+
 '''
-from __future__ import absolute_import
 from builtins import object
 from elixir.statements import Statement
 import sqlalchemy as sa

--- a/elixir/ext/encrypted.py
+++ b/elixir/ext/encrypted.py
@@ -31,8 +31,6 @@ instance has been flushed to the database (and thus encrypted), the value for
 that attribute will be crypted in the in-memory object in addition to the
 database row.
 '''
-from __future__ import absolute_import
-
 from builtins import object
 from Crypto.Cipher import Blowfish
 from elixir.statements import Statement

--- a/elixir/ext/encrypted.py
+++ b/elixir/ext/encrypted.py
@@ -62,7 +62,7 @@ def decrypt_value(value, secret):
 # acts_as_encrypted statement
 #
 
-class ActsAsEncrypted(object):
+class ActsAsEncrypted:
 
     def __init__(self, entity, for_fields=[], with_secret='abcdef'):
 

--- a/elixir/ext/encrypted.py
+++ b/elixir/ext/encrypted.py
@@ -31,7 +31,6 @@ instance has been flushed to the database (and thus encrypted), the value for
 that attribute will be crypted in the in-memory object in addition to the
 database row.
 '''
-from builtins import object
 from Crypto.Cipher import Blowfish
 from elixir.statements import Statement
 from sqlalchemy.orm import MapperExtension, EXT_CONTINUE, EXT_STOP

--- a/elixir/ext/perform_ddl.py
+++ b/elixir/ext/perform_ddl.py
@@ -45,7 +45,6 @@ entity table from a list of tuples (of fields values for each row).
                      [(1982, u'Blade Runner')])
         preload_data(data=[(u'Batman', 1966)])
 '''
-from builtins import zip
 from elixir.statements import Statement
 from elixir.properties import EntityBuilder
 from sqlalchemy import DDL

--- a/elixir/ext/perform_ddl.py
+++ b/elixir/ext/perform_ddl.py
@@ -45,8 +45,6 @@ entity table from a list of tuples (of fields values for each row).
                      [(1982, u'Blade Runner')])
         preload_data(data=[(u'Batman', 1966)])
 '''
-from __future__ import absolute_import
-
 from builtins import zip
 from elixir.statements import Statement
 from elixir.properties import EntityBuilder

--- a/elixir/ext/versioned.py
+++ b/elixir/ext/versioned.py
@@ -44,8 +44,6 @@ Note that relationships that are stored in mapping tables will not be included
 as part of the versioning process, and will need to be handled manually. Only
 values within the entity's main table will be versioned into the history table.
 '''
-from __future__ import absolute_import
-
 from builtins import object
 from datetime              import datetime
 import inspect

--- a/elixir/ext/versioned.py
+++ b/elixir/ext/versioned.py
@@ -44,7 +44,6 @@ Note that relationships that are stored in mapping tables will not be included
 as part of the versioning process, and will need to be handled manually. Only
 values within the entity's main table will be versioned into the history table.
 '''
-from builtins import object
 from datetime              import datetime
 import inspect
 

--- a/elixir/ext/versioned.py
+++ b/elixir/ext/versioned.py
@@ -196,7 +196,7 @@ class VersionedEntityBuilder(EntityBuilder):
         entity.__history_table__ = table
 
         # create an object that represents a version of this entity
-        class Version(object):
+        class Version:
             pass
 
         # map the version class to the history table for this entity

--- a/elixir/fields.py
+++ b/elixir/fields.py
@@ -105,8 +105,6 @@ Here is a quick example of how to use ``has_field``.
         has_field('id', Integer, primary_key=True)
         has_field('name', String(50))
 '''
-from __future__ import absolute_import
-
 from past.builtins import basestring
 from sqlalchemy import Column
 from sqlalchemy.orm import deferred, synonym

--- a/elixir/fields.py
+++ b/elixir/fields.py
@@ -105,7 +105,6 @@ Here is a quick example of how to use ``has_field``.
         has_field('id', Integer, primary_key=True)
         has_field('name', String(50))
 '''
-from past.builtins import basestring
 from sqlalchemy import Column
 from sqlalchemy.orm import deferred, synonym
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -163,7 +162,7 @@ class Field(Property):
     def create_properties(self):
         if self.deferred:
             group = None
-            if isinstance(self.deferred, basestring):
+            if isinstance(self.deferred, str):
                 group = self.deferred
             self.property = deferred(self.column, group=group)
         elif self.name != self.colname:

--- a/elixir/options.py
+++ b/elixir/options.py
@@ -177,8 +177,6 @@ not work on normal entities, and the normal using_options statement does not
 work on base classes (because normal options do not and should not propagate to
 the children classes).
 '''
-from __future__ import absolute_import
-
 from sqlalchemy import Integer, String
 
 from elixir.statements import ClassMutator

--- a/elixir/properties.py
+++ b/elixir/properties.py
@@ -35,7 +35,7 @@ from sqlalchemy.orm import column_property, synonym
 __doc_all__ = ['EntityBuilder', 'Property', 'GenericProperty',
                'ColumnProperty']
 
-class EntityBuilder(object):
+class EntityBuilder:
     '''
     Abstract base class for all entity builders. An Entity builder is a class
     of objects which can be added to an Entity (usually by using special

--- a/elixir/properties.py
+++ b/elixir/properties.py
@@ -32,7 +32,6 @@ Here is a quick example of how to use ``has_property``.
 from builtins import object
 from elixir.statements import PropertyStatement
 from sqlalchemy.orm import column_property, synonym
-from future.utils import with_metaclass
 
 __doc_all__ = ['EntityBuilder', 'Property', 'GenericProperty',
                'ColumnProperty']
@@ -106,7 +105,7 @@ class CounterMeta(type):
         return instance
 
 
-class Property(with_metaclass(CounterMeta, EntityBuilder)):
+class Property(EntityBuilder, metaclass=CounterMeta):
     '''
     Abstract base class for all properties of an Entity.
     '''

--- a/elixir/properties.py
+++ b/elixir/properties.py
@@ -29,8 +29,6 @@ Here is a quick example of how to use ``has_property``.
                      lambda c: column_property(
                          (c.quantity * c.unit_price).label('price')))
 '''
-from __future__ import absolute_import
-
 from builtins import object
 from elixir.statements import PropertyStatement
 from sqlalchemy.orm import column_property, synonym

--- a/elixir/properties.py
+++ b/elixir/properties.py
@@ -29,7 +29,6 @@ Here is a quick example of how to use ``has_property``.
                      lambda c: column_property(
                          (c.quantity * c.unit_price).label('price')))
 '''
-from builtins import object
 from elixir.statements import PropertyStatement
 from sqlalchemy.orm import column_property, synonym
 

--- a/elixir/relationships.py
+++ b/elixir/relationships.py
@@ -399,7 +399,6 @@ ManyToMany_ relationships.
         has_and_belongs_to_many('articles', of_kind='Article')
 
 '''
-from builtins import str, zip
 import warnings
 
 from sqlalchemy import ForeignKeyConstraint, Column, Table, and_

--- a/elixir/relationships.py
+++ b/elixir/relationships.py
@@ -400,7 +400,6 @@ ManyToMany_ relationships.
 
 '''
 from builtins import str, zip
-from past.builtins import basestring
 import warnings
 
 from sqlalchemy import ForeignKeyConstraint, Column, Table, and_
@@ -491,7 +490,7 @@ class Relationship(Property):
     @property
     def target(self):
         if not self._target:
-            if isinstance(self.of_kind, basestring):
+            if isinstance(self.of_kind, str):
                 collection = self.entity._descriptor.collection
                 self._target = collection.resolve(self.of_kind, self.entity)
             else:

--- a/elixir/relationships.py
+++ b/elixir/relationships.py
@@ -399,8 +399,6 @@ ManyToMany_ relationships.
         has_and_belongs_to_many('articles', of_kind='Article')
 
 '''
-from __future__ import absolute_import, print_function
-
 from builtins import str, zip
 from past.builtins import basestring
 import warnings

--- a/elixir/statements.py
+++ b/elixir/statements.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import object
 import sys
 

--- a/elixir/statements.py
+++ b/elixir/statements.py
@@ -2,7 +2,7 @@ import sys
 
 MUTATORS = '__elixir_mutators__'
 
-class ClassMutator(object):
+class ClassMutator:
     '''
     DSL-style syntax
 

--- a/elixir/statements.py
+++ b/elixir/statements.py
@@ -1,4 +1,3 @@
-from builtins import object
 import sys
 
 MUTATORS = '__elixir_mutators__'

--- a/examples/videostore/setup.py
+++ b/examples/videostore/setup.py
@@ -1,64 +1,64 @@
-from past.builtins import execfile
 from setuptools import setup, find_packages
 from turbogears.finddata import find_package_data
 
 import os
-execfile(os.path.join("videostore", "release.py"))
 
-setup(
-    name="videostore",
-    version=version,
+with open(os.path.join("videostore", "release.py")) as f:
+    exec(f.read())
 
-    # uncomment the following lines if you fill them out in release.py
-    #description=description,
-    #author=author,
-    #author_email=email,
-    #url=url,
-    #download_url=download_url,
-    #license=license,
+    setup(
+        name="videostore",
+        version=version,
 
-    install_requires = [
-        "TurboGears >= 1.0",
-        "SQLAlchemy",
-    ],
-    scripts = ["start-videostore.py"],
-    zip_safe=False,
-    packages=find_packages(),
-    package_data = find_package_data(where='videostore',
-                                     package='videostore'),
-    keywords = [
-        # Use keywords if you'll be adding your package to the
-        # Python Cheeseshop
+        # uncomment the following lines if you fill them out in release.py
+        #description=description,
+        #author=author,
+        #author_email=email,
+        #url=url,
+        #download_url=download_url,
+        #license=license,
 
-        # if this has widgets, uncomment the next line
-        # 'turbogears.widgets',
+        install_requires = [
+            "TurboGears >= 1.0",
+            "SQLAlchemy",
+        ],
+        scripts = ["start-videostore.py"],
+        zip_safe=False,
+        packages=find_packages(),
+        package_data = find_package_data(where='videostore',
+                                        package='videostore'),
+        keywords = [
+            # Use keywords if you'll be adding your package to the
+            # Python Cheeseshop
 
-        # if this has a tg-admin command, uncomment the next line
-        # 'turbogears.command',
+            # if this has widgets, uncomment the next line
+            # 'turbogears.widgets',
 
-        # if this has identity providers, uncomment the next line
-        # 'turbogears.identity.provider',
+            # if this has a tg-admin command, uncomment the next line
+            # 'turbogears.command',
 
-        # If this is a template plugin, uncomment the next line
-        # 'python.templating.engines',
+            # if this has identity providers, uncomment the next line
+            # 'turbogears.identity.provider',
 
-        # If this is a full application, uncomment the next line
-        # 'turbogears.app',
-    ],
-    classifiers = [
-        'Development Status :: 3 - Alpha',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Framework :: TurboGears',
-        # if this is an application that you'll distribute through
-        # the Cheeseshop, uncomment the next line
-        # 'Framework :: TurboGears :: Applications',
+            # If this is a template plugin, uncomment the next line
+            # 'python.templating.engines',
 
-        # if this is a package that includes widgets that you'll distribute
-        # through the Cheeseshop, uncomment the next line
-        # 'Framework :: TurboGears :: Widgets',
-    ],
-    test_suite = 'nose.collector',
-    )
+            # If this is a full application, uncomment the next line
+            # 'turbogears.app',
+        ],
+        classifiers = [
+            'Development Status :: 3 - Alpha',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python',
+            'Topic :: Software Development :: Libraries :: Python Modules',
+            'Framework :: TurboGears',
+            # if this is an application that you'll distribute through
+            # the Cheeseshop, uncomment the next line
+            # 'Framework :: TurboGears :: Applications',
 
+            # if this is a package that includes widgets that you'll distribute
+            # through the Cheeseshop, uncomment the next line
+            # 'Framework :: TurboGears :: Widgets',
+        ],
+        test_suite = 'nose.collector',
+        )

--- a/examples/videostore/setup.py
+++ b/examples/videostore/setup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from past.builtins import execfile
 from setuptools import setup, find_packages
 from turbogears.finddata import find_package_data

--- a/examples/videostore/start-videostore.py
+++ b/examples/videostore/start-videostore.py
@@ -1,5 +1,4 @@
 #!/Library/Frameworks/Python.framework/Versions/2.4/Resources/Python.app/Contents/MacOS/Python
-from __future__ import absolute_import
 import pkg_resources
 pkg_resources.require("TurboGears")
 

--- a/examples/videostore/videostore/controllers/__init__.py
+++ b/examples/videostore/videostore/controllers/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import
 from videostore.controllers.root import Root

--- a/examples/videostore/videostore/controllers/root.py
+++ b/examples/videostore/videostore/controllers/root.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from turbogears.controllers     import RootController
 from videostore.model           import Movie, Director, Actor
 from turbogears                 import identity, redirect, expose

--- a/examples/videostore/videostore/json.py
+++ b/examples/videostore/videostore/json.py
@@ -6,6 +6,5 @@
 # @jsonify can convert your objects to following types:
 # lists, dicts, numbers and strings
 
-from __future__ import absolute_import
 from turbojson.jsonify import jsonify
 

--- a/examples/videostore/videostore/model.py
+++ b/examples/videostore/videostore/model.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from turbogears.database    import metadata, session
 from elixir                 import Unicode, DateTime, String, Integer
 from elixir                 import Entity, Field, using_options

--- a/examples/videostore/videostore/tests/test_controllers.py
+++ b/examples/videostore/videostore/tests/test_controllers.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import turbogears
 from nose import with_setup
 from turbogears import testutil

--- a/examples/videostore/videostore/tests/test_model.py
+++ b/examples/videostore/videostore/tests/test_model.py
@@ -4,7 +4,6 @@
 # choice for testing, because you can use an in-memory database
 # which is very fast.
 
-from __future__ import absolute_import
 from turbogears import testutil, database
 # from videostore.model import YourDataClass, User
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name="Elixir",
-      version="1.0.1",
+      version="2.0.0",
       description="Declarative Mapper for SQLAlchemy",
       long_description="""
 Elixir

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ SVN version: <http://elixir.ematia.de/svn/elixir/trunk#egg=Elixir-dev>
       license="MIT License",
       install_requires=[
           "SQLAlchemy == 1.3.24",
-          "future"
       ],
       packages=find_packages(exclude=['ez_setup', 'tests', 'examples']),
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 setup(name="Elixir",

--- a/tests/a.py
+++ b/tests/a.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from elixir import *
 
 class A(Entity):

--- a/tests/b.py
+++ b/tests/b.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from elixir import *
 
 class B(Entity):

--- a/tests/db1/__init__.py
+++ b/tests/db1/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import
 from . import a, b, c

--- a/tests/db1/a.py
+++ b/tests/db1/a.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from elixir import Entity, ManyToOne, OneToMany, ManyToMany, using_options
 
 class A1(Entity):

--- a/tests/db1/b.py
+++ b/tests/db1/b.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from elixir import Entity, ManyToMany, using_options
 
 class B(Entity):

--- a/tests/db1/c.py
+++ b/tests/db1/c.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from elixir import Entity, ManyToMany
 
 class C(Entity):

--- a/tests/db2/__init__.py
+++ b/tests/db2/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import
 from . import a

--- a/tests/db2/a.py
+++ b/tests/db2/a.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from elixir import Entity, ManyToMany
 
 class A(Entity):

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,7 +1,6 @@
 """
 test inheritance with abstract entities
 """
-from builtins import object
 import re
 
 from elixir import *

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,8 +1,6 @@
 """
 test inheritance with abstract entities
 """
-from __future__ import absolute_import
-
 from builtins import object
 import re
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -23,7 +23,7 @@ def setup():
 def teardown():
     elixir.options_defaults['shortnames'] = False
 
-class TestAbstractInheritance(object):
+class TestAbstractInheritance:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_associable.py
+++ b/tests/test_associable.py
@@ -10,7 +10,7 @@ from elixir.ext.associable import associable
 def setup():
     metadata.bind = 'sqlite://'
 
-class TestOrders(object):
+class TestOrders:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_associable.py
+++ b/tests/test_associable.py
@@ -1,7 +1,6 @@
 """
 Test the associable statement generator
 """
-from builtins import object
 from sqlalchemy import and_
 
 from elixir import *

--- a/tests/test_associable.py
+++ b/tests/test_associable.py
@@ -1,8 +1,6 @@
 """
 Test the associable statement generator
 """
-from __future__ import absolute_import
-
 from builtins import object
 from sqlalchemy import and_
 

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -1,8 +1,6 @@
 """
 test autoloaded entities
 """
-from __future__ import absolute_import
-
 from builtins import object
 from sqlalchemy import Table, Column, ForeignKey
 from elixir import *

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -23,7 +23,7 @@ def teardown():
 
 # -----------
 
-class TestAutoload(object):
+class TestAutoload:
     def setup(self):
         metadata.bind = 'sqlite://'
 

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -1,7 +1,6 @@
 """
 test autoloaded entities
 """
-from builtins import object
 from sqlalchemy import Table, Column, ForeignKey
 from elixir import *
 import elixir

--- a/tests/test_class_methods.py
+++ b/tests/test_class_methods.py
@@ -5,7 +5,7 @@ from elixir import *
 
 #-----------
 
-class TestOldMethods(object):
+class TestOldMethods:
     def setup(self):
         metadata.bind = 'sqlite://'
 

--- a/tests/test_class_methods.py
+++ b/tests/test_class_methods.py
@@ -1,7 +1,6 @@
 """
     simple test case
 """
-from builtins import object
 from elixir import *
 
 #-----------

--- a/tests/test_class_methods.py
+++ b/tests/test_class_methods.py
@@ -1,8 +1,6 @@
 """
     simple test case
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -12,7 +12,7 @@ def setup():
 def teardown():
     cleanup_all()
 
-class TestCollections(object):
+class TestCollections:
     def teardown(self):
         cleanup_all()
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,8 +1,6 @@
 """
 Test collections
 """
-from __future__ import absolute_import
-
 from builtins import object
 from sqlalchemy import Table
 from elixir import *

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,7 +1,6 @@
 """
 Test collections
 """
-from builtins import object
 from sqlalchemy import Table
 from elixir import *
 import elixir

--- a/tests/test_custombase.py
+++ b/tests/test_custombase.py
@@ -14,7 +14,7 @@ def setup():
             for key, value in list(kwargs.items()):
                 setattr(self, key, value)
 
-class TestCustomBase(object):
+class TestCustomBase:
     def teardown(self):
         cleanup_all(True)
 
@@ -37,7 +37,7 @@ class TestCustomBase(object):
         # create a meta entity which mimick cases where dir() method
         # will report attribute that can't be directly accessed.
         # Note: this happens with zope.interface. See ticket #98.
-        class BrokenDescriptor(object):
+        class BrokenDescriptor:
             def __get__(*args):
                 raise AttributeError
 
@@ -70,7 +70,7 @@ class TestCustomBase(object):
         assert b.data == '-b1-'
 
     def test_non_object_base(self):
-        class BaseParent(object):
+        class BaseParent:
             def test(self):
                 return "success"
 
@@ -126,7 +126,7 @@ class TestCustomBase(object):
         assert 'common_id' in B.table.columns
 
     def test_base_with_fields_in_parent(self):
-        class BaseParent(object):
+        class BaseParent:
             common1 = Field(String(32))
 
         class FieldBase(BaseParent, metaclass=EntityMeta):

--- a/tests/test_custombase.py
+++ b/tests/test_custombase.py
@@ -4,14 +4,13 @@ test having entities using a custom base class
 from builtins import object
 from elixir import *
 import elixir
-from future.utils import with_metaclass
 
 def setup():
     metadata.bind = 'sqlite://'
 
     global MyBase
 
-    class MyBase(with_metaclass(EntityMeta, object)):
+    class MyBase(metaclass=EntityMeta):
         def __init__(self, **kwargs):
             for key, value in list(kwargs.items()):
                 setattr(self, key, value)
@@ -43,7 +42,7 @@ class TestCustomBase(object):
             def __get__(*args):
                 raise AttributeError
 
-        class MyEntity(with_metaclass(EntityMeta, EntityBase)):
+        class MyEntity(metaclass=EntityMeta):
             d = BrokenDescriptor()
 
         class A(MyEntity):
@@ -76,7 +75,7 @@ class TestCustomBase(object):
             def test(self):
                 return "success"
 
-        class InheritedBase(with_metaclass(EntityMeta, BaseParent)):
+        class InheritedBase(BaseParent, metaclass=EntityMeta):
             pass
 
         class A(InheritedBase):
@@ -96,7 +95,7 @@ class TestCustomBase(object):
         assert a.test() == "success"
 
     def test_base_with_fields(self):
-        class FieldBase(with_metaclass(EntityMeta, object)):
+        class FieldBase(metaclass=EntityMeta):
             common = Field(String(32))
 
         class A(FieldBase):
@@ -112,7 +111,7 @@ class TestCustomBase(object):
         assert 'common' in B.table.columns
 
     def test_base_with_relation(self):
-        class FieldBase(with_metaclass(EntityMeta, object)):
+        class FieldBase(metaclass=EntityMeta):
             common = ManyToOne('A')
 
         class A(FieldBase):
@@ -131,7 +130,7 @@ class TestCustomBase(object):
         class BaseParent(object):
             common1 = Field(String(32))
 
-        class FieldBase(with_metaclass(EntityMeta, BaseParent)):
+        class FieldBase(BaseParent, metaclass=EntityMeta):
             common2 = Field(String(32))
 
         class A(FieldBase):
@@ -154,7 +153,7 @@ class TestCustomBase(object):
         def camel_to_underscore(entity):
             return re.sub(r'(.+?)([A-Z])+?', r'\1_\2', entity.__name__).lower()
 
-        class OptionBase(with_metaclass(EntityMeta, object)):
+        class OptionBase(metaclass=EntityMeta):
             options_defaults = dict(tablename=camel_to_underscore)
             using_options_defaults(identity=camel_to_underscore)
             using_options_defaults(inheritance='multi')
@@ -176,7 +175,7 @@ class TestCustomBase(object):
 
         collection = elixir.collection.RelativeEntityCollection()
 
-        class Base(with_metaclass(EntityMeta, object)):
+        class Base(metaclass=EntityMeta):
             using_options_defaults(collection=collection)
 
         class A(Base):
@@ -200,7 +199,7 @@ class TestCustomBase(object):
     def test_base_custom_session(self):
         from sqlalchemy.orm import sessionmaker
 
-        class Base(with_metaclass(EntityMeta, object)):
+        class Base(metaclass=EntityMeta):
             using_options_defaults(session=None)
 
         class A(Base):

--- a/tests/test_custombase.py
+++ b/tests/test_custombase.py
@@ -1,7 +1,6 @@
 """
 test having entities using a custom base class
 """
-from builtins import object
 from elixir import *
 import elixir
 

--- a/tests/test_custombase.py
+++ b/tests/test_custombase.py
@@ -1,8 +1,6 @@
 """
 test having entities using a custom base class
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 import elixir

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,8 +1,6 @@
 """
     test the deep-set functionality
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,7 +1,6 @@
 """
     test the deep-set functionality
 """
-from builtins import object
 from elixir import *
 
 def setup():

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -28,7 +28,7 @@ def setup():
 def teardown():
     cleanup_all()
 
-class TestDeepSet(object):
+class TestDeepSet:
     def setup(self):
         create_all()
 
@@ -153,7 +153,7 @@ class TestDeepSet(object):
                          'tbl3': {'t3id': 1,
                                   'name': 'test3'}}}
 
-class TestSetOnAliasedColumn(object):
+class TestSetOnAliasedColumn:
     def setup(self):
         metadata.bind = 'sqlite://'
         session.expunge_all()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,7 +4,7 @@ from elixir.events import *
 from sqlalchemy import Table, Column
 
 
-class TestEvents(object):
+class TestEvents:
     def teardown(self):
         cleanup_all(True)
 
@@ -104,7 +104,7 @@ class TestEvents(object):
         checkCount('reconstructor_called', 2)
 
     def test_multiple_inheritance(self):
-        class AddEventMethods(object):
+        class AddEventMethods:
             update_count = 0
 
             @after_update
@@ -127,7 +127,7 @@ class TestEvents(object):
         assert a.update_count == 1
 
     def test_entity_wh_bad_descriptors(self):
-        class BrokenDescriptor(object):
+        class BrokenDescriptor:
             def __get__(*args):
                 raise AttributeError
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 from elixir.events import *

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,4 +1,3 @@
-from builtins import object
 from elixir import *
 from elixir.events import *
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,6 @@
 """
 test the different syntaxes to define fields
 """
-from builtins import object
 from elixir import *
 
 def setup():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,7 +6,7 @@ from elixir import *
 def setup():
     metadata.bind = 'sqlite://'
 
-class TestFields(object):
+class TestFields:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,6 @@
 """
 test the different syntaxes to define fields
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_inherit.py
+++ b/tests/test_inherit.py
@@ -1,8 +1,6 @@
 """
 test inheritance
 """
-from __future__ import absolute_import, print_function
-
 from builtins import zip
 from builtins import object
 from elixir import *

--- a/tests/test_inherit.py
+++ b/tests/test_inherit.py
@@ -61,7 +61,7 @@ def do_tst(inheritance, polymorphic, expected_res):
             assert real.__class__.__name__ == expected
 
 
-class TestInheritance(object):
+class TestInheritance:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_inherit.py
+++ b/tests/test_inherit.py
@@ -1,8 +1,6 @@
 """
 test inheritance
 """
-from builtins import zip
-from builtins import object
 from elixir import *
 import elixir
 

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -1,8 +1,6 @@
 """
 test many to many relationships
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 import elixir

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import configure_mappers
 
 #-----------
 
-class TestManyToMany(object):
+class TestManyToMany:
     def setup(self):
         metadata.bind = 'sqlite://'
 

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -1,7 +1,6 @@
 """
 test many to many relationships
 """
-from builtins import object
 from elixir import *
 import elixir
 from sqlalchemy.orm import configure_mappers

--- a/tests/test_m2o.py
+++ b/tests/test_m2o.py
@@ -1,7 +1,6 @@
 """
 test many to one relationships
 """
-from builtins import object
 from elixir import *
 
 def setup():

--- a/tests/test_m2o.py
+++ b/tests/test_m2o.py
@@ -1,8 +1,6 @@
 """
 test many to one relationships
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_m2o.py
+++ b/tests/test_m2o.py
@@ -6,7 +6,7 @@ from elixir import *
 def setup():
     metadata.bind = 'sqlite://'
 
-class TestManyToOne(object):
+class TestManyToOne:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_nestedclass.py
+++ b/tests/test_nestedclass.py
@@ -15,7 +15,7 @@ def setup():
 
     setup_all()
 
-class TestNestedClass(object):
+class TestNestedClass:
     def test_nestedclass(self):
         assert 'name' in Thing.table.columns
         assert 'type' in Thing.table.columns

--- a/tests/test_nestedclass.py
+++ b/tests/test_nestedclass.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_nestedclass.py
+++ b/tests/test_nestedclass.py
@@ -1,4 +1,3 @@
-from builtins import object
 from elixir import *
 
 def setup():

--- a/tests/test_o2m.py
+++ b/tests/test_o2m.py
@@ -1,8 +1,6 @@
 """
 test one to many relationships
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 from sqlalchemy import and_

--- a/tests/test_o2m.py
+++ b/tests/test_o2m.py
@@ -1,7 +1,6 @@
 """
 test one to many relationships
 """
-from builtins import object
 from elixir import *
 from sqlalchemy import and_
 from sqlalchemy.ext.orderinglist import ordering_list

--- a/tests/test_o2m.py
+++ b/tests/test_o2m.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.orderinglist import ordering_list
 def setup():
     metadata.bind = 'sqlite://'
 
-class TestOneToMany(object):
+class TestOneToMany:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_o2o.py
+++ b/tests/test_o2o.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_o2o.py
+++ b/tests/test_o2o.py
@@ -1,4 +1,3 @@
-from builtins import object
 from elixir import *
 
 def setup():

--- a/tests/test_o2o.py
+++ b/tests/test_o2o.py
@@ -3,7 +3,7 @@ from elixir import *
 def setup():
     metadata.bind = "sqlite://"
 
-class TestOneToOne(object):
+class TestOneToOne:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,8 +1,6 @@
 """
 test options
 """
-from __future__ import absolute_import
-
 from builtins import object
 from sqlalchemy import UniqueConstraint, create_engine, Column
 from sqlalchemy.orm import scoped_session, sessionmaker

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,7 +1,6 @@
 """
 test options
 """
-from builtins import object
 from sqlalchemy import UniqueConstraint, create_engine, Column
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.exc import StatementError

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import StatementError
 from sqlalchemy.orm.exc import ConcurrentModificationError
 from elixir import *
 
-class TestOptions(object):
+class TestOptions:
     def setup(self):
         metadata.bind = 'sqlite://'
 
@@ -88,7 +88,7 @@ class TestOptions(object):
         options_defaults['tablename'] = None
 
 
-class TestSessionOptions(object):
+class TestSessionOptions:
     def setup(self):
         metadata.bind = None
 
@@ -182,7 +182,7 @@ class TestSessionOptions(object):
         del __session__
 
 
-class TestTableOptions(object):
+class TestTableOptions:
     def setup(self):
         metadata.bind = 'sqlite://'
 

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -1,8 +1,6 @@
 """
 test ordering options
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -1,7 +1,6 @@
 """
 test ordering options
 """
-from builtins import object
 from elixir import *
 
 

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -57,7 +57,7 @@ def teardown():
     cleanup_all()
 
 
-class TestOrderBy(object):
+class TestOrderBy:
     def teardown(self):
         session.expunge_all()
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -12,7 +12,7 @@ def setup():
         sys.modules.pop('tests.%s' % module, None)
 
 
-class TestPackages(object):
+class TestPackages:
     def teardown(self):
         # This is an ugly workaround because when nosetest is run globally (ie
         # either on the tests directory or in the "trunk" directory, it imports

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,7 +1,6 @@
 """
 Test spreading entities accross several modules
 """
-from builtins import object
 import sys
 
 import elixir

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,8 +1,6 @@
 """
 Test spreading entities accross several modules
 """
-from __future__ import absolute_import
-
 from builtins import object
 import sys
 

--- a/tests/test_perform_ddl.py
+++ b/tests/test_perform_ddl.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 from elixir.ext.perform_ddl import perform_ddl, preload_data

--- a/tests/test_perform_ddl.py
+++ b/tests/test_perform_ddl.py
@@ -6,7 +6,7 @@ def setup():
     metadata.bind = "sqlite://"
 
 
-class TestPerformDDL(object):
+class TestPerformDDL:
     def teardown(self):
         cleanup_all(True)
 
@@ -37,7 +37,7 @@ class TestPerformDDL(object):
         setup_all(True)
         assert Movie.query.count() == 3
 
-class TestPreloadData(object):
+class TestPreloadData:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_perform_ddl.py
+++ b/tests/test_perform_ddl.py
@@ -1,4 +1,3 @@
-from builtins import object
 from elixir import *
 from elixir.ext.perform_ddl import perform_ddl, preload_data
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -9,7 +9,7 @@ def setup():
     metadata.bind = 'sqlite://'
 
 
-class TestSpecialProperties(object):
+class TestSpecialProperties:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,7 +1,6 @@
 """
 test special properties (eg. column_property, ...)
 """
-from builtins import object
 from sqlalchemy import select, func
 from sqlalchemy.orm import column_property
 from elixir import *

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,8 +1,6 @@
 """
 test special properties (eg. column_property, ...)
 """
-from __future__ import absolute_import
-
 from builtins import object
 from sqlalchemy import select, func
 from sqlalchemy.orm import column_property

--- a/tests/test_sa_integration.py
+++ b/tests/test_sa_integration.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import *
 from sqlalchemy import *
 from elixir import *
 
-class TestSQLAlchemyToElixir(object):
+class TestSQLAlchemyToElixir:
     def setup(self):
         metadata.bind = "sqlite://"
 
@@ -27,7 +27,7 @@ class TestSQLAlchemyToElixir(object):
         )
         b_table.create()
 
-        class B(object):
+        class B:
             pass
 
         mapper(B, b_table, properties={
@@ -47,7 +47,7 @@ class TestSQLAlchemyToElixir(object):
         assert b.a.name == 'a1'
 
 
-class TestElixirToSQLAlchemy(object):
+class TestElixirToSQLAlchemy:
     def setup(self):
         metadata.bind = "sqlite://"
 
@@ -61,7 +61,7 @@ class TestElixirToSQLAlchemy(object):
         )
         a_table.create()
 
-        class A(object):
+        class A:
             pass
 
         mapper(A, a_table)
@@ -91,7 +91,7 @@ class TestElixirToSQLAlchemy(object):
         )
         a_table.create()
 
-        class A(object):
+        class A:
             pass
 
         mapper(A, a_table)
@@ -125,7 +125,7 @@ class TestElixirToSQLAlchemy(object):
 #        )
 #        a_table.create()
 #
-#        class A(object):
+#        class A:
 #            pass
 #
 #        mapper(A, a_table)

--- a/tests/test_sa_integration.py
+++ b/tests/test_sa_integration.py
@@ -1,8 +1,6 @@
 """
 test integrating Elixir entities with plain SQLAlchemy defined classes
 """
-from __future__ import absolute_import
-
 from builtins import object
 from sqlalchemy.orm import *
 from sqlalchemy import *

--- a/tests/test_sa_integration.py
+++ b/tests/test_sa_integration.py
@@ -1,7 +1,6 @@
 """
 test integrating Elixir entities with plain SQLAlchemy defined classes
 """
-from builtins import object
 from sqlalchemy.orm import *
 from sqlalchemy import *
 from elixir import *

--- a/tests/test_through.py
+++ b/tests/test_through.py
@@ -1,8 +1,6 @@
 """
     test has_*(..., through=...) syntax
 """
-from __future__ import absolute_import
-
 from builtins import object
 from elixir import *
 from datetime import datetime

--- a/tests/test_through.py
+++ b/tests/test_through.py
@@ -8,7 +8,7 @@ def setup():
     metadata.bind = 'sqlite://'
 
 
-class TestThrough(object):
+class TestThrough:
     def teardown(self):
         cleanup_all(True)
 

--- a/tests/test_through.py
+++ b/tests/test_through.py
@@ -1,7 +1,6 @@
 """
     test has_*(..., through=...) syntax
 """
-from builtins import object
 from elixir import *
 from datetime import datetime
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from builtins import object
 import time
 from datetime import datetime

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,4 +1,3 @@
-from builtins import object
 import time
 from datetime import datetime
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -5,7 +5,7 @@ from elixir import *
 from elixir.ext.versioned import acts_as_versioned
 
 
-class TestVersioning(object):
+class TestVersioning:
     def teardown(self):
         cleanup_all(True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3,py38,py39
+envlist = py27,py3,py38,py39,py311
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27,py3,py38,py39,py311
+envlist = py3,py38,py39,py311
 skipsdist = True
 
 [testenv]
 deps =
     SQLAlchemy==1.3.24
     nose
-    future
 commands =
     nosetests


### PR DESCRIPTION
Ticket: https://chownow.atlassian.net/browse/CN-42522

- Removes unneeded `__future__` imports.
- Removes usage of `past` imports for Hermosa python 3.11 compatibility.
- Updates version to `2.0.0`.